### PR TITLE
Add main application class and initial project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # TestGenie
 A simple CLI tool that scans your Java methods and generates intelligent JUnit 5 test stubs — **fully offline** and no setup needed.
 
+The Applications main point of entry is src/main/java/com/testgenie/App.java
+
 ## Features
 
 - Parses any Java class file in the /samples directory.

--- a/README.md
+++ b/README.md
@@ -3,15 +3,29 @@ A simple CLI tool that scans your Java methods and generates intelligent JUnit 5
 
 ## Features
 
-- Parses any Java class file
-- Analyzes methods and logic
-- Generates readable, compilable JUnit5 tests
-- Runs 100% locally
+- Parses any Java class file in the /samples directory.
+- Analyzes the methods and logic.
+- Generates readable, compilable JUnit5 test cases in the output/ directory appended by Test.
+- Runs locally within the CLI with no dependencies.
 
 ## How to Run
 
-1. Clone and build:
+### 1. Clone and Build
 ```bash
 git clone https://github.com/yourname/testgenie.git
 cd testgenie
 ./gradlew build
+```
+### 2. Run the Project
+You can run the project on the samples in the samples folder by running the following command:
+```bash
+./gradlew run --args="samples/Calculator.java"
+```
+You can replace the args value with other java files other than Calculator. 
+The test cases will get created under the **ouput** directory appended by Test. For example, the command above will generate the following filename in the output directory: **CalculatorTest.java**
+
+### 3. Review the TestCase Output
+For convenience, you can run the **cat** terminal command on the test file like so:
+```bash
+cat output/CalculatorTest.java
+```

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id 'java'
+    id 'application'
 }
 
-group = 'com.bradltr'
+group = 'com.testgenie'
 version = '1.0-SNAPSHOT'
 
 repositories {
@@ -10,10 +11,14 @@ repositories {
 }
 
 dependencies {
-    testImplementation platform('org.junit:junit-bom:5.10.0')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
+    implementation 'com.github.javaparser:javaparser-core:3.25.4'
+    implementation 'info.picocli:picocli:4.7.5'
 }
 
-test {
-    useJUnitPlatform()
+application {
+    mainClass = 'com.testgenie.App'
+}
+
+tasks.withType(JavaExec) {
+    standardInput = System.in
 }

--- a/src/main/java/com/testgenie/App.java
+++ b/src/main/java/com/testgenie/App.java
@@ -1,0 +1,8 @@
+package com.testgenie;
+
+public class App {
+    public static void main(String[] args) {
+        // Standard outputs should not be used to directly log anything. This is just Stub code for now.
+        System.out.println("Test Genie App");
+    }
+}


### PR DESCRIPTION
- Created the main App.java class where the project will kick off from.
- Updated the README to include where the main app is running.
- Uses the application plugin and sets the main class to com.testgenie.App.
- Ensures gradle explicity forwards the terminals input stream.
- Use the application plugin and set the main class com.testgenie.App. The project now runs using ./gradlew run.
- Ensures gradle explicitly forwards the terminals input stream to prevent any issues running the project locally.