### PR TITLE
Feature/create javafileparser component

### DIFF
--- a/src/main/java/com/testgenie/JavaFileParser.java
+++ b/src/main/java/com/testgenie/JavaFileParser.java
@@ -2,6 +2,7 @@ package com.testgenie;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 
@@ -60,6 +61,27 @@ public class JavaFileParser {
         } catch(Exception e) {
             // If parsing fails, return an empty list instead of throwing and return an error message
             System.err.println("Failed to parse file: " + e.getMessage());
+            return List.of();
+        }
+    }
+
+    /**
+     * Parses a given Java file and extracts the class or interface name.
+     * This method is used to capture the name of the file and prefixing it with Test during the TestGeneration.
+     *
+     * @param file The Java source file to parse.
+     * @return A list of ClassOrInterfaceDeclaration nodes found in the file.
+     *      Returns an empty list if parsing fails or no fields are found.
+     */
+    public static List<ClassOrInterfaceDeclaration> parseClassOrInterfaceName(File file) {
+        try {
+            CompilationUnit compUnit = StaticJavaParser.parse(file);
+
+            return compUnit.findAll(ClassOrInterfaceDeclaration.class)
+                    .stream()
+                    .toList();
+        } catch(Exception e) {
+            System.err.println("Failed to parse file for ClassOrInterfanceName: " + e.getMessage());
             return List.of();
         }
     }

--- a/src/main/java/com/testgenie/JavaFileParser.java
+++ b/src/main/java/com/testgenie/JavaFileParser.java
@@ -7,7 +7,6 @@ import com.github.javaparser.ast.body.MethodDeclaration;
 
 import java.io.File;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * JavaFileParser is responsible for:
@@ -35,7 +34,7 @@ public class JavaFileParser {
             // Find all method declarations in the file and return them
             return compUnit.findAll(MethodDeclaration.class)
                     .stream()
-                    .collect(Collectors.toList());
+                    .toList();
 
         } catch(Exception e) {
             // If parsing fails, return an empty list instead of throwing and return an error message
@@ -57,7 +56,7 @@ public class JavaFileParser {
 
             return compUnit.findAll(FieldDeclaration.class)
                     .stream()
-                    .collect(Collectors.toList());
+                    .toList();
         } catch(Exception e) {
             // If parsing fails, return an empty list instead of throwing and return an error message
             System.err.println("Failed to parse file: " + e.getMessage());

--- a/src/main/java/com/testgenie/JavaFileParser.java
+++ b/src/main/java/com/testgenie/JavaFileParser.java
@@ -1,0 +1,45 @@
+package com.testgenie;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.MethodDeclaration;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * JavaFileParser is responsible for:
+ * - Parsing Java source files using JavaParser.
+ * - Extracting all method declarations from the source code.
+ * - Returning them as a list of MethodDeclaration objects.
+ *
+ * This class uses StaticJavaParser for simplicity, which provides a static entry point
+ * to parse files without explicitly creating a JavaParser configuration.
+ */
+public class JavaFileParser {
+
+    /**
+     * Parses a given Java file and extracts all method declarations.
+     *
+     * @param file The Java source file to parse.
+     * @return A list of MethodDeclaration nodes found in the file.
+     *         Returns an empty list if parsing fails or no methods are found.
+     */
+    public static List<MethodDeclaration> parseMethods(File file) {
+        try {
+            // Parse the Java file into a CompilationUnit (AST root)
+            CompilationUnit compUnit = StaticJavaParser.parse(file);
+
+            // Find all method declarations in the file and return them
+            return compUnit.findAll(MethodDeclaration.class)
+                    .stream()
+                    .collect(Collectors.toList());
+
+        } catch(Exception e) {
+            // If parsing fails, return an empty list instead of throwing and return an error message
+            System.err.println("Failed to parse file: " + e.getMessage());
+            return List.of();
+        }
+    }
+}

--- a/src/main/java/com/testgenie/JavaFileParser.java
+++ b/src/main/java/com/testgenie/JavaFileParser.java
@@ -39,7 +39,7 @@ public class JavaFileParser {
 
         } catch(Exception e) {
             // If parsing fails, return an empty list instead of throwing and return an error message
-            System.err.println("Failed to parse file: " + e.getMessage());
+            System.err.println("Failed to parse file for methods: " + e.getMessage());
             return List.of();
         }
     }
@@ -60,7 +60,7 @@ public class JavaFileParser {
                     .toList();
         } catch(Exception e) {
             // If parsing fails, return an empty list instead of throwing and return an error message
-            System.err.println("Failed to parse file: " + e.getMessage());
+            System.err.println("Failed to parse file for class fields: " + e.getMessage());
             return List.of();
         }
     }

--- a/src/main/java/com/testgenie/JavaFileParser.java
+++ b/src/main/java/com/testgenie/JavaFileParser.java
@@ -2,6 +2,7 @@ package com.testgenie;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 
 import java.io.File;
@@ -36,6 +37,27 @@ public class JavaFileParser {
                     .stream()
                     .collect(Collectors.toList());
 
+        } catch(Exception e) {
+            // If parsing fails, return an empty list instead of throwing and return an error message
+            System.err.println("Failed to parse file: " + e.getMessage());
+            return List.of();
+        }
+    }
+
+    /**
+     * Parses a given Java file and extracts all field declarations.
+     *
+     * @param file The Java source file to parse.
+     * @return A list of FieldDeclaration nodes found in the file.
+     *         Returns an empty list if parsing fails or no fields are found.
+     */
+    public static List<FieldDeclaration> parseFields(File file) {
+        try {
+            CompilationUnit compUnit = StaticJavaParser.parse(file);
+
+            return compUnit.findAll(FieldDeclaration.class)
+                    .stream()
+                    .collect(Collectors.toList());
         } catch(Exception e) {
             // If parsing fails, return an empty list instead of throwing and return an error message
             System.err.println("Failed to parse file: " + e.getMessage());


### PR DESCRIPTION
- Uses StaticJavaParser to parse .java files into a CompilationUnit AST
- Extracts all MethodDeclaration nodes from the file
- Returns method declarations as a List for use in test generation
- Falls back to an empty list on parsing failure for safety
- Added parseFields to JavaFileParser to retrieve all FieldDeclaration instances using JavaParser. This enables utilities to analyze class-level metadata, such as instance variables like `balance` in the BankAccount.java sample used for test generation.
- Added parseClassOrInterfaceName to JavaFileParser to retrieve the ClassOrInterfaceDeclaration using JavaParser.
- This allows us to extract the name of the class or interface, which is important for generating meaningful test class names.
- For example, if the source file defines a class BankAccount, we can generate a test class named TestBankAccount.