### PR TITLE
Develop -> Main::Get A Single Class Name Instead of A List Of Class Names

### DIFF
--- a/src/main/java/com/testgenie/JavaFileParser.java
+++ b/src/main/java/com/testgenie/JavaFileParser.java
@@ -1,0 +1,88 @@
+package com.testgenie;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * JavaFileParser is responsible for:
+ * - Parsing Java source files using JavaParser.
+ * - Extracting all method declarations from the source code.
+ * - Returning them as a list of MethodDeclaration objects.
+ *
+ * This class uses StaticJavaParser for simplicity, which provides a static entry point
+ * to parse files without explicitly creating a JavaParser configuration.
+ */
+public class JavaFileParser {
+
+    /**
+     * Parses a given Java file and extracts all method declarations.
+     *
+     * @param file The Java source file to parse.
+     * @return A list of MethodDeclaration nodes found in the file.
+     *         Returns an empty list if parsing fails or no methods are found.
+     */
+    public static List<MethodDeclaration> parseMethods(File file) {
+        try {
+            // Parse the Java file into a CompilationUnit (AST root)
+            CompilationUnit compUnit = StaticJavaParser.parse(file);
+
+            // Find all method declarations in the file and return them
+            return compUnit.findAll(MethodDeclaration.class)
+                    .stream()
+                    .toList();
+
+        } catch(Exception e) {
+            // If parsing fails, return an empty list instead of throwing and return an error message
+            System.err.println("Failed to parse file for methods: " + e.getMessage());
+            return List.of();
+        }
+    }
+
+    /**
+     * Parses a given Java file and extracts all field declarations.
+     *
+     * @param file The Java source file to parse.
+     * @return A list of FieldDeclaration nodes found in the file.
+     *         Returns an empty list if parsing fails or no fields are found.
+     */
+    public static List<FieldDeclaration> parseFields(File file) {
+        try {
+            CompilationUnit compUnit = StaticJavaParser.parse(file);
+
+            return compUnit.findAll(FieldDeclaration.class)
+                    .stream()
+                    .toList();
+        } catch(Exception e) {
+            // If parsing fails, return an empty list instead of throwing and return an error message
+            System.err.println("Failed to parse file for class fields: " + e.getMessage());
+            return List.of();
+        }
+    }
+
+    /**
+     * Parses a given Java file and extracts the class or interface name.
+     * This method is used to capture the name of the file and prefixing it with Test during the TestGeneration.
+     *
+     * @param file The Java source file to parse.
+     * @return A list of ClassOrInterfaceDeclaration nodes found in the file.
+     *      Returns an empty list if parsing fails or no fields are found.
+     */
+    public static List<ClassOrInterfaceDeclaration> parseClassOrInterfaceName(File file) {
+        try {
+            CompilationUnit compUnit = StaticJavaParser.parse(file);
+
+            return compUnit.findAll(ClassOrInterfaceDeclaration.class)
+                    .stream()
+                    .toList();
+        } catch(Exception e) {
+            System.err.println("Failed to parse file for ClassOrInterfanceName: " + e.getMessage());
+            return List.of();
+        }
+    }
+}

--- a/src/main/java/com/testgenie/JavaFileParser.java
+++ b/src/main/java/com/testgenie/JavaFileParser.java
@@ -8,6 +8,7 @@ import com.github.javaparser.ast.body.MethodDeclaration;
 
 import java.io.File;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * JavaFileParser is responsible for:
@@ -73,16 +74,17 @@ public class JavaFileParser {
      * @return A list of ClassOrInterfaceDeclaration nodes found in the file.
      *      Returns an empty list if parsing fails or no fields are found.
      */
-    public static List<ClassOrInterfaceDeclaration> parseClassOrInterfaceName(File file) {
+    public static Optional<String> parseClassOrInterfaceName(File file) {
         try {
             CompilationUnit compUnit = StaticJavaParser.parse(file);
 
             return compUnit.findAll(ClassOrInterfaceDeclaration.class)
                     .stream()
-                    .toList();
+                    .findFirst()
+                    .map(ClassOrInterfaceDeclaration::getNameAsString);
         } catch(Exception e) {
             System.err.println("Failed to parse file for ClassOrInterfanceName: " + e.getMessage());
-            return List.of();
+            return Optional.empty();
         }
     }
 }


### PR DESCRIPTION
For simplicity, were just going to assume a single class per file and return its name as an Optional<String> 
rather than a list of ClassOrInterfaceDeclarationNames.