### PR TITLE
refactor: move util methods into StringUtil

### DIFF
--- a/src/main/java/com/testgenie/TestGenerator.java
+++ b/src/main/java/com/testgenie/TestGenerator.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+import static com.testgenie.utils.StringUtil.*;
+
 /**
  * TestGenerator is responsible for generating a unit test file for a given Java source file.
  * It uses the JavaFileParser utility to extract class information and builds a test class
@@ -111,21 +113,5 @@ public class TestGenerator {
         } catch (IOException e) {
             System.err.println("Error writing test file: " + e.getMessage());
         }
-    }
-
-    /**
-     * Lowercases the first character of a given string.
-     */
-    private String lowercaseFirst(String str) {
-        if (str == null || str.isEmpty()) return str;
-        return Character.toLowerCase(str.charAt(0)) + str.substring(1);
-    }
-
-    /**
-     * Capitalizes the first character of a given string.
-     */
-    private String capitalizeFirst(String str) {
-        if (str == null || str.isEmpty()) return str;
-        return Character.toUpperCase(str.charAt(0)) + str.substring(1);
     }
 }

--- a/src/main/java/com/testgenie/utils/StringUtil.java
+++ b/src/main/java/com/testgenie/utils/StringUtil.java
@@ -1,0 +1,22 @@
+package com.testgenie.utils;
+
+/**
+ * String utility method's used by the TestGenerator to ensure formatting is consistent for test stubs.
+ */
+public class StringUtil {
+    /**
+     * Lowercases the first character of a given string.
+     */
+    public static String lowercaseFirst(String str) {
+        if (str == null || str.isEmpty()) return str;
+        return Character.toLowerCase(str.charAt(0)) + str.substring(1);
+    }
+
+    /**
+     * Capitalizes the first character of a given string.
+     */
+    public static String capitalizeFirst(String str) {
+        if (str == null || str.isEmpty()) return str;
+        return Character.toUpperCase(str.charAt(0)) + str.substring(1);
+    }
+}


### PR DESCRIPTION
Separate the utility methods that are unrelated to the TestGenerator class into its own StringUtility class. This also creates a common place to store future string utility methods.