### PR TITLE
feat: Add ability for flags to be optional

### DIFF
--- a/src/main/java/com/testgenie/TestGenerator.java
+++ b/src/main/java/com/testgenie/TestGenerator.java
@@ -114,7 +114,7 @@ public class TestGenerator {
 
             // Create the test stubs for any of the conditions above that are true
             // Generate stub for null-check logic
-            if (hasNullCheck && flags.contains("null")) {
+            if (hasNullCheck && (flags.isEmpty() || flags.contains("null"))) {
                 testContent.append(INDENT).append("@Test\n")
                         .append(INDENT).append("void ").append(testMethodName).append("_nullCheck() {\n")
                         .append(INDENT).append(INDENT).append("// TODO: verify null handling\n")
@@ -125,7 +125,7 @@ public class TestGenerator {
             }
 
             // Generate stub for exception-throwing methods
-            if (throwsException && flags.contains("exceptions")) {
+            if (throwsException && (flags.isEmpty() || flags.contains("exceptions"))) {
                 testContent.append(INDENT).append(TEST_ANNOTATION + "\n")
                         .append(INDENT).append("void ").append(testMethodName).append("_throwsException() {\n")
                         .append(INDENT).append(INDENT).append("// TODO: verify exception thrown\n")
@@ -136,7 +136,7 @@ public class TestGenerator {
             }
 
             // Generate stub for conditional logic (if/switch)
-            if (hasConditional && flags.contains("conditionals")) {
+            if (hasConditional && (flags.isEmpty() || flags.contains("conditionals"))) {
                 testContent.append(INDENT).append(TEST_ANNOTATION + "\n")
                         .append(INDENT).append("void ").append(testMethodName).append("_conditionals() {\n")
                         .append(INDENT).append(INDENT).append("// TODO: verify branching logic\n")
@@ -145,7 +145,7 @@ public class TestGenerator {
             }
 
             // Generate stub for Optional-returning methods
-            if (usesOptional && flags.contains("optionals")) {
+            if (usesOptional && (flags.isEmpty() || flags.contains("optionals"))) {
                 testContent.append(INDENT).append(TEST_ANNOTATION + "\n")
                         .append(INDENT).append("void ").append(testMethodName).append("_returnsOptional() {\n")
                         .append(INDENT).append(INDENT).append("// TODO: test Optional presence/absence\n")
@@ -155,7 +155,7 @@ public class TestGenerator {
             }
 
             // Generate stub for boolean-returning methods
-            if (returnsBoolean && flags.contains("booleans")) {
+            if (returnsBoolean && (flags.isEmpty() || flags.contains("booleans"))) {
                 testContent.append(INDENT).append(TEST_ANNOTATION + "\n")
                         .append(INDENT).append("void ").append(testMethodName).append("_returnsBoolean() {\n")
                         .append(INDENT).append(INDENT).append("// TODO: test true/false conditions\n")
@@ -165,7 +165,7 @@ public class TestGenerator {
             }
 
             // Generate stub for state-changing methods
-            if (changesState && flags.contains("state")) {
+            if (changesState && (flags.isEmpty() || flags.contains("state"))) {
                 testContent.append(INDENT).append(TEST_ANNOTATION + "\n")
                         .append(INDENT).append("void ").append(testMethodName).append("_changesState() {\n")
                         .append(INDENT).append(INDENT).append("// TODO: verify side effects or state changes\n")


### PR DESCRIPTION
- If no flags are provided, generate all possible test stubs by default.
- Previously, flags were required after the recent changes, but now users can skip them and still get the full set of generated tests.