### PR TITLE
feat: Add GenerationOptions helper class and ignore flag support

### DIFF
--- a/src/main/java/com/testgenie/App.java
+++ b/src/main/java/com/testgenie/App.java
@@ -3,6 +3,7 @@ package com.testgenie;
 import picocli.CommandLine;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
@@ -23,8 +24,14 @@ public class App implements Callable<Integer> {
             description = "Flags to filter which test stubs are generated",
             split = ","
     )
+    private final Set<String> FLAGS = new HashSet<>();
 
-    private Set<String> flags;
+    @CommandLine.Option(
+            names = {"--ignore"},
+            description = "Flags to ignore which test stubs are generated",
+            split = ","
+    )
+    private final Set<String> IGNORE = new HashSet<>();
 
     public static void main(String[] args) {
         int exitCode = new CommandLine(new App()).execute(args);
@@ -42,7 +49,7 @@ public class App implements Callable<Integer> {
 
         try {
             // This method will generate the test class and write the file to outputDir
-            generator.generateTestFile(inputFile, outputDir, flags);
+            generator.generateTestFile(inputFile, outputDir, FLAGS, IGNORE);
         } catch (Exception e) {
             System.err.println("Failed to generate test file: " + e.getMessage());
             e.printStackTrace();

--- a/src/main/java/com/testgenie/GenerationOptions.java
+++ b/src/main/java/com/testgenie/GenerationOptions.java
@@ -1,0 +1,18 @@
+package com.testgenie;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class GenerationOptions {
+    private static Set<String> flags = new HashSet<>();
+    private static Set<String> ignoreFlags = new HashSet<>();
+
+    public GenerationOptions(Set<String> flags, Set<String> ignoreFlags) {
+        GenerationOptions.flags = flags;
+        GenerationOptions.ignoreFlags = ignoreFlags;
+    }
+
+    public boolean shouldGenerate(String flag) {
+        return (flags.isEmpty() || flags.contains(flag)) && (ignoreFlags.isEmpty() || !ignoreFlags.contains(flag));
+    }
+}

--- a/src/main/java/com/testgenie/TestGenerator.java
+++ b/src/main/java/com/testgenie/TestGenerator.java
@@ -24,14 +24,13 @@ import static com.testgenie.utils.StringUtil.*;
 public class TestGenerator {
     private static final String INDENT = "    ";
     private static final String TEST_ANNOTATION = "@Test";
-
     /**
      * Entry point to generate the test file.
      *
      * @param sourceFile The original Java file to generate test stubs for.
      * @param outputDir The output directory to write the test file to. This should be the output directory.
      */
-    public void generateTestFile(File sourceFile, String outputDir, Set<String> flags) {
+    public void generateTestFile(File sourceFile, String outputDir, Set<String> flags, Set<String> ignoreFlags) {
         StringBuilder testContent = new StringBuilder();
         testContent.append("package com.testgenie.generated;\n\n")
                 .append("import org.junit.jupiter.api.BeforeEach;\n")
@@ -85,6 +84,8 @@ public class TestGenerator {
                 .append(INDENT)
                 .append("}\n\n");
 
+        GenerationOptions options = new GenerationOptions(flags, ignoreFlags);
+
         // Iterate over public methods and generate condition-based test stubs
         for (MethodDeclaration method : methods) {
             // Only generate test methods for public methods
@@ -114,7 +115,7 @@ public class TestGenerator {
 
             // Create the test stubs for any of the conditions above that are true
             // Generate stub for null-check logic
-            if (hasNullCheck && (flags.isEmpty() || flags.contains("null"))) {
+            if (hasNullCheck && options.shouldGenerate("null")) {
                 testContent.append(INDENT).append("@Test\n")
                         .append(INDENT).append("void ").append(testMethodName).append("_nullCheck() {\n")
                         .append(INDENT).append(INDENT).append("// TODO: verify null handling\n")
@@ -125,7 +126,7 @@ public class TestGenerator {
             }
 
             // Generate stub for exception-throwing methods
-            if (throwsException && (flags.isEmpty() || flags.contains("exceptions"))) {
+            if (throwsException && options.shouldGenerate("exceptions")) {
                 testContent.append(INDENT).append(TEST_ANNOTATION + "\n")
                         .append(INDENT).append("void ").append(testMethodName).append("_throwsException() {\n")
                         .append(INDENT).append(INDENT).append("// TODO: verify exception thrown\n")
@@ -136,7 +137,7 @@ public class TestGenerator {
             }
 
             // Generate stub for conditional logic (if/switch)
-            if (hasConditional && (flags.isEmpty() || flags.contains("conditionals"))) {
+            if (hasConditional && options.shouldGenerate("conditionals")) {
                 testContent.append(INDENT).append(TEST_ANNOTATION + "\n")
                         .append(INDENT).append("void ").append(testMethodName).append("_conditionals() {\n")
                         .append(INDENT).append(INDENT).append("// TODO: verify branching logic\n")
@@ -145,7 +146,7 @@ public class TestGenerator {
             }
 
             // Generate stub for Optional-returning methods
-            if (usesOptional && (flags.isEmpty() || flags.contains("optionals"))) {
+            if (usesOptional && options.shouldGenerate("options")) {
                 testContent.append(INDENT).append(TEST_ANNOTATION + "\n")
                         .append(INDENT).append("void ").append(testMethodName).append("_returnsOptional() {\n")
                         .append(INDENT).append(INDENT).append("// TODO: test Optional presence/absence\n")
@@ -155,7 +156,7 @@ public class TestGenerator {
             }
 
             // Generate stub for boolean-returning methods
-            if (returnsBoolean && (flags.isEmpty() || flags.contains("booleans"))) {
+            if (returnsBoolean && options.shouldGenerate("booleans")) {
                 testContent.append(INDENT).append(TEST_ANNOTATION + "\n")
                         .append(INDENT).append("void ").append(testMethodName).append("_returnsBoolean() {\n")
                         .append(INDENT).append(INDENT).append("// TODO: test true/false conditions\n")
@@ -165,7 +166,7 @@ public class TestGenerator {
             }
 
             // Generate stub for state-changing methods
-            if (changesState && (flags.isEmpty() || flags.contains("state"))) {
+            if (changesState && options.shouldGenerate("state")) {
                 testContent.append(INDENT).append(TEST_ANNOTATION + "\n")
                         .append(INDENT).append("void ").append(testMethodName).append("_changesState() {\n")
                         .append(INDENT).append(INDENT).append("// TODO: verify side effects or state changes\n")


### PR DESCRIPTION
- Introduced GenerationOptions class to centralize flag and ignore flag handling.

- Replaced inline flag-checking logic in TestGenerator with the cleaner shouldGenerate(String flag) method.

- Added new --ignore command-line option to skip generating certain test stubs.

- Converted flags and ignoreFlags to final fields for immutability and clarity.

This change reduces repetitive conditional checks, improves readability, and adds flexibility for excluding specific tests.